### PR TITLE
Add types for TypeScript users

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,0 +1,39 @@
+declare namespace kdljs {
+  /**
+   * A {@link https://github.com/kdl-org/kdl/blob/main/SPEC.md#document|Document}.
+   */
+  export type Document = Node[];
+
+  /**
+   * A {@link https://github.com/kdl-org/kdl/blob/main/SPEC.md#node|Node}.
+   */
+  export interface Node {
+    /** The name of the Node */
+    name: string;
+    /** Collection of {@link https://github.com/kdl-org/kdl/blob/main/SPEC.md#argument|Arguments} */
+    values: Value[];
+    /** Collection of {@link https://github.com/kdl-org/kdl/blob/main/SPEC.md#property|Properties} */
+    properties: Record<string, Value>;
+    /** Nodes in the {@link https://github.com/kdl-org/kdl/blob/main/SPEC.md#children-block|Children block} */
+    children: Document;
+  }
+
+  /**
+   * A {@link https://github.com/kdl-org/kdl/blob/main/SPEC.md#value|Value}.
+   */
+  export type Value = string | number | boolean | null;
+
+  export interface ParseResult {
+    /** Parsing errors */
+    errors: chevrotain.IRecognitionException[];
+    /** KDL Document */
+    output?: Document;
+  }
+}
+
+/**
+  * @param {string} text - Input KDL file (or fragment)
+  */
+declare function parse(text: string): kdljs.ParseResult;
+
+export = parse;

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "0.0.2",
   "description": "KDL parser and serializer.",
   "main": "index.js",
+  "types": "index.d.ts",
   "scripts": {
     "lint": "standard",
     "test": "mocha --throw-deprecation test/spec.js",


### PR DESCRIPTION
Hello there—I'm really loving KDL and this parser is great! I thought it would be nice to publish types for TypeScript (or generally VS Code) users.

These are hand-written for now based on the existing JSDoc comments, but it would also be possible to generate them from TypeScript-style JSDoc comments. If you'd be interested in going that route, I'm happy to update this PR. If you'd prefer not to maintain types alongside this package, I'm happy to publish these to [DefinitelyTyped](https://github.com/DefinitelyTyped/DefinitelyTyped).