### PR TITLE
[bugfix] Treat standalone carriage return as newline

### DIFF
--- a/parser.js
+++ b/parser.js
@@ -27,7 +27,7 @@ const BlockComment = createToken({ name: 'BlockComment', pattern: /\/-/ })
 const LineComment = createToken({
   name: 'LineComment',
   // eslint-disable-next-line no-control-regex
-  pattern: /\/\/(\x0D(?!\x0A)|[^\x0A\x0C\x0D\x85\u2028\u2029])*/,
+  pattern: /\/\/[^\x0A\x0C\x0D\x85\u2028\u2029]*/,
   line_breaks: true
 })
 const OpenMultiLineComment = createToken({

--- a/parser.js
+++ b/parser.js
@@ -21,7 +21,7 @@ const BOM = createToken({
 const NewLine = createToken({
   name: 'NewLine',
   // eslint-disable-next-line no-control-regex
-  pattern: /\x0D\x0A|[\x0A\x0C\x85\u2028\u2029]/
+  pattern: /\x0D\x0A|[\x0A\x0D\x0C\x85\u2028\u2029]/
 })
 const BlockComment = createToken({ name: 'BlockComment', pattern: /\/-/ })
 const LineComment = createToken({

--- a/parser.js
+++ b/parser.js
@@ -21,7 +21,7 @@ const BOM = createToken({
 const NewLine = createToken({
   name: 'NewLine',
   // eslint-disable-next-line no-control-regex
-  pattern: /\x0D\x0A|[\x0A\x0D\x0C\x85\u2028\u2029]/
+  pattern: /\x0D\x0A|[\x0A\x0C\x0D\x85\u2028\u2029]/
 })
 const BlockComment = createToken({ name: 'BlockComment', pattern: /\/-/ })
 const LineComment = createToken({


### PR DESCRIPTION
The existing code correctly handles CRLF, treating it as a single newline. However, it does not appear to treat a standalone carriage return as a newline. According to [the spec](https://github.com/kdl-org/kdl/blob/1.0.0/SPEC.md#newline), carriage returns should be treated as a newline.

Steps to reproduce:

```js
> kdl.parse("foo\r\nbar")
{
  output: [
    { name: 'foo', properties: {}, values: [], children: [] },
    { name: 'bar', properties: {}, values: [], children: [] }
  ],
  errors: []
}

> kdl.parse("foo\rbar")
{
  output: undefined,
  errors: [
    EarlyExitException: Expecting: expecting at least one iteration which starts with one of these possible Token sequences::
      <[BOM] ,[WhiteSpace] ,[OpenMultiLineComment] ,[EscLine]>
    but found: 'bar'
        <...stacktrace...>  {
      token: [Object],
      resyncedTokens: [],
      previousToken: [Object],
      context: [Object]
    }
  ]
}
```