### PR TITLE
[bugfix] Do not include non ident chars in idents

### DIFF
--- a/parser.js
+++ b/parser.js
@@ -66,7 +66,7 @@ const Integer = createToken({
 // Other
 const Identifier = createToken({
   name: 'Identifier',
-  pattern: /(?![+-]\d)[\x21-\x27\x2A-\x2E\x3A\x3F-\x5A\x5E-\x7A\x7C\x7E-\uFFFF][\x21-\x27\x2A-\x2E\x30-\x3A\x3F-\x5A\x5E-\x7A\x7C\x7E-\uFFFF]*/
+  pattern: /(?![+-]\d)[\x21\x23-\x27\x2A\x2B\x2D\x2E\x3A\x3F-\x5A\x5E-\x7A\x7C\x7E-\uFFFF][\x21\x23-\x27\x2A\x2B\x2D\x2E\x30-\x3A\x3F-\x5A\x5E-\x7A\x7C\x7E-\uFFFF]*/
 })
 const SemiColon = createToken({ name: 'SemiColon', pattern: /;/ })
 const Equals = createToken({ name: 'Equals', pattern: /=/ })


### PR DESCRIPTION
According to [the spec](https://github.com/kdl-org/kdl/blob/1.0.0/SPEC.md#non-identifier-characters), the following chars are not allowed in identifiers: `\/<>{};=,"`. While it looks like most of those are excluded here, I noticed that the double quote `"` and comma `,` characters are being included.

Steps to reproduce:

```js
> kdl.parse("foo,")
{
  output: [ { name: 'foo,', properties: {}, values: [], children: [] } ],
  errors: []
}

> kdl.parse("foo\"")
{
  output: [ { name: 'foo"', properties: {}, values: [], children: [] } ],
  errors: []
}
```

Please note that the resulting behavior after this change seems questionable. An exception is raised when a double quote is included in the identifier (which I would expect). However, when commas are present, they seem to be silently ignored. I'm not intimately familiar with the spec or implementations, so I'm not sure what the correct behavior is (though I would expect exceptions in both cases). Looking for any feedback on approach here!