### PR TITLE
fix(types): remove kdljs typescript namespace

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -77,7 +77,7 @@ export function parse(text: string): ParseResult;
 /**
  * @param {Document} doc - Input KDL document
  */
-export function format( doc: Document, options?: FormattingOptions,): string;
+export function format(doc: Document, options?: FormattingOptions): string;
 
 /**
  * @param {Document} doc - Input KDL document

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,93 +1,91 @@
 import "chevrotain";
 
-declare namespace kdljs {
-  /**
-   * A {@link https://github.com/kdl-org/kdl/blob/main/SPEC.md#document|Document}.
-   */
-  export type Document = Node[];
+/**
+ * A {@link https://github.com/kdl-org/kdl/blob/main/SPEC.md#document|Document}.
+ */
+export type Document = Node[];
 
-  /**
-   * A {@link https://github.com/kdl-org/kdl/blob/main/SPEC.md#node|Node}.
-   */
-  export interface Node {
-    /** The name of the Node */
-    name: string;
-    /** Collection of {@link https://github.com/kdl-org/kdl/blob/main/SPEC.md#argument|Arguments} */
-    values: Value[];
-    /** Collection of {@link https://github.com/kdl-org/kdl/blob/main/SPEC.md#property|Properties} */
-    properties: Record<string, Value>;
-    /** Nodes in the {@link https://github.com/kdl-org/kdl/blob/main/SPEC.md#children-block|Children block} */
-    children: Document;
-    /** Collection of {@link https://github.com/kdl-org/kdl/blob/main/SPEC.md#type-annotation|type annotations} */
-    tags: NodeTypeAnnotations;
-  }
+/**
+ * A {@link https://github.com/kdl-org/kdl/blob/main/SPEC.md#node|Node}.
+ */
+export interface Node {
+  /** The name of the Node */
+  name: string;
+  /** Collection of {@link https://github.com/kdl-org/kdl/blob/main/SPEC.md#argument|Arguments} */
+  values: Value[];
+  /** Collection of {@link https://github.com/kdl-org/kdl/blob/main/SPEC.md#property|Properties} */
+  properties: Record<string, Value>;
+  /** Nodes in the {@link https://github.com/kdl-org/kdl/blob/main/SPEC.md#children-block|Children block} */
+  children: Document;
+  /** Collection of {@link https://github.com/kdl-org/kdl/blob/main/SPEC.md#type-annotation|type annotations} */
+  tags: NodeTypeAnnotations;
+}
 
-  /**
-   * A {@link https://github.com/kdl-org/kdl/blob/main/SPEC.md#value|Value}.
-   */
-  export type Value = string | number | boolean | null;
+/**
+ * A {@link https://github.com/kdl-org/kdl/blob/main/SPEC.md#value|Value}.
+ */
+export type Value = string | number | boolean | null;
 
-  /**
-   * The {@link https://github.com/kdl-org/kdl/blob/main/SPEC.md#type-annotation|Type annotations} associated with a {@link https://github.com/kdl-org/kdl/blob/main/SPEC.md#node|Node}.
-   */
-  export interface NodeTypeAnnotations {
-    /** The type annotation of the Node */
-    name: string;
-    /** The type annotations of the {@link https://github.com/kdl-org/kdl/blob/main/SPEC.md#argument|Arguments} */
-    values: string[];
-    /** The type annotations of the {@link https://github.com/kdl-org/kdl/blob/main/SPEC.md#property|Properties} */
-    properties: Record<string, string>;
-  }
+/**
+ * The {@link https://github.com/kdl-org/kdl/blob/main/SPEC.md#type-annotation|Type annotations} associated with a {@link https://github.com/kdl-org/kdl/blob/main/SPEC.md#node|Node}.
+ */
+export interface NodeTypeAnnotations {
+  /** The type annotation of the Node */
+  name: string;
+  /** The type annotations of the {@link https://github.com/kdl-org/kdl/blob/main/SPEC.md#argument|Arguments} */
+  values: string[];
+  /** The type annotations of the {@link https://github.com/kdl-org/kdl/blob/main/SPEC.md#property|Properties} */
+  properties: Record<string, string>;
+}
 
-  /**
-   * A {@link https://github.com/kdl-org/kdl/blob/main/QUERY-SPEC.md|Query string}.
-   */
-  export type QueryString = string;
+/**
+ * A {@link https://github.com/kdl-org/kdl/blob/main/QUERY-SPEC.md|Query string}.
+ */
+export type QueryString = string;
 
-  export interface ParseResult {
-    /** Parsing errors */
-    errors: chevrotain.IRecognitionException[];
-    /** KDL Document */
-    output?: Document;
-  }
+export interface ParseResult {
+  /** Parsing errors */
+  errors: chevrotain.IRecognitionException[];
+  /** KDL Document */
+  output?: Document;
+}
 
-  /**
-   * Formatting options
-   */
-  export interface FormattingOptions {
-    escapes?: Record<number, boolean>;
-    requireSemicolons?: boolean;
-    escapeNonAscii?: boolean;
-    escapeNonPrintableAscii?: boolean;
-    escapeCommon?: boolean;
-    escapeLinespace?: boolean;
-    newline?: string;
-    indent?: number;
-    indentChar?: string;
-    exponentChar?: string;
-    printEmptyChildren?: boolean;
-    printNullArgs?: boolean;
-    printNullProps?: boolean;
-  }
+/**
+ * Formatting options
+ */
+export interface FormattingOptions {
+  escapes?: Record<number, boolean>;
+  requireSemicolons?: boolean;
+  escapeNonAscii?: boolean;
+  escapeNonPrintableAscii?: boolean;
+  escapeCommon?: boolean;
+  escapeLinespace?: boolean;
+  newline?: string;
+  indent?: number;
+  indentChar?: string;
+  exponentChar?: string;
+  printEmptyChildren?: boolean;
+  printNullArgs?: boolean;
+  printNullProps?: boolean;
 }
 
 /**
  * @param {string} text - Input KDL file (or fragment)
  */
-export function parse(text: string): kdljs.ParseResult;
+export function parse(text: string): ParseResult;
 
 /**
- * @param {kdljs.Document} doc - Input KDL document
+ * @param {Document} doc - Input KDL document
  */
-export function format(doc: kdljs.Document, options?: kdljs.FormattingOptions): string;
+export function format( doc: Document, options?: FormattingOptions,): string;
 
 /**
- * @param {kdljs.Document} doc - Input KDL document
- * @param {kdljs.QueryString} queryString - Query for selecting and/or transforming results
+ * @param {Document} doc - Input KDL document
+ * @param {QueryString} queryString - Query for selecting and/or transforming results
  */
-export function query(doc: kdljs.Document, queryString: kdljs.QueryString): any;
+export function query(doc: Document, queryString: QueryString): any;
 
 /**
- * @param {kdljs.Document} doc - KDL document
+ * @param {Document} doc - KDL document
  */
-export function validateDocument(doc: kdljs.Document): boolean;
+export function validateDocument(doc: Document): boolean;


### PR DESCRIPTION
Fixes #19

Breaking change for typescript users.

---

This diff may look big but it is only 2 logical changes:

1. Remove the outer kdljs namespace block & dedent the code accordingly
2. Delete all references to the `kdljs.' namespace

Line 80 got 2 other changes because I formatted with prettier but they seem better to me. Happy to go into "change the fewest bytes possible" mode if anyone is fussy about PRs that way here.

The unit tests still pass fine and my project compiles fine under typescript with this change. The big caveat here is that I am a typescript novice so not confident about this change.

This change I think would count as a bugfix for JS users but would be considered breaking for TS users, and I don't know what the means for semver and changelog purposes. My suspicion is I am one of a very small number of users of both kdljs with typescript at the moment.

