### PR TITLE
perf(parser): remove backtracking

### DIFF
--- a/src/parser/base.js
+++ b/src/parser/base.js
@@ -79,14 +79,13 @@ class BaseParser extends EmbeddedActionsParser {
     })
 
     /**
-     * Consume a value
-     * @method #value
+     * Consume a non-string value
+     * @method #nonStringValue
      * @memberof module:kdljs.parser.base.BaseParser
      * @return {module:kdljs~Value}
      */
-    this.RULE('value', () => {
+    this.RULE('nonStringValue', () => {
       return this.OR([
-        { ALT: () => this.SUBRULE(this.string) },
         { ALT: () => this.CONSUME(Tokens.Boolean).image === '#true' },
         {
           ALT: () => {
@@ -114,6 +113,19 @@ class BaseParser extends EmbeddedActionsParser {
             return sign * parseInt(number.slice(1), radix[number[0]])
           }
         }
+      ])
+    })
+
+    /**
+     * Consume a value
+     * @method #value
+     * @memberof module:kdljs.parser.base.BaseParser
+     * @return {module:kdljs~Value}
+     */
+    this.RULE('value', () => {
+      return this.OR([
+        { ALT: () => this.SUBRULE(this.string) },
+        { ALT: () => this.SUBRULE(this.nonStringValue) }
       ])
     })
 
@@ -376,12 +388,15 @@ class BaseParser extends EmbeddedActionsParser {
      * Consume node space
      * @method #nodeSpace
      * @memberof module:kdljs.parser.kdl.BaseParser
+     * @returns {boolean}
      */
     this.RULE('nodeSpace', () => {
       this.AT_LEAST_ONE(() => this.OR([
         { ALT: () => this.SUBRULE(this.whiteSpace) },
         { ALT: () => this.SUBRULE(this.lineContinuation) }
       ]))
+
+      return true
     })
 
     /**


### PR DESCRIPTION
I noticed a performance regression when updating my benchmark to the new kdljs version.
Chevrotain is very slow at backtracking. Removing all backtracking results in a 7x faster parse time on my benchmark document and a 14x faster parse time on the KDL Playground's default document.

```
bench before x 1,695 ops/sec ±0.38% (99 runs sampled)
bench after x 12,230 ops/sec ±0.62% (96 runs sampled)

play before x 6,355 ops/sec ±0.33% (97 runs sampled)
play after x 88,774 ops/sec ±0.23% (99 runs sampled)
```

<details>
<summary>The document used in the benchmark</summary>

```kdl
node \
{
	child; "child"; ###"child"###;
}

deeply { nested { node { but { like { really { deeply { nested { or { whatever; }; }; }; }; }; }; }; }; }

node \
  with="a lot" \
  #"no really,"#="a lot" \
  #"no really,"#="a lot" \
  #"no really,"#="a lot" \
  #"no really,"#="a lot" \
  #"no really,"#="a lot" \
  #"no really,"#="a lot" \
  #"no really,"#="a lot" \
  #"no really,"#="a lot" \
  #"no really,"#="a lot" \
  #"no really,"#="a lot" \
  #"no really,"#="a lot" \
  #"no really,"#="a lot" \
  #"no really,"#="a lot" \
  #"no really,"#="a lot" \
  #"no really,"#="a lot" \
	"of" "children" 4.20;
```

</details>

<details>
<summary>Playground document</summary>

```kdl
foo 1 "two" three=(decimal)0xff {
  (thing)bar #true #false #null
}
```

</details>

This PR changes the way properties and arguments are parsed. The way this is defined in the spec requires unbounded lookahead due to the support for node-space between a property name and the equals sign, and unbounded lookahead only works in chevrotain if you use backtracking.
This PR changes the parser to use a different but equivalent ruleset to parse properties and arguments:

- Does it start with a tag? It is an argument
- Is it a non-string value? It is an argument
- Is it a string value? Check if it's followed by an equals sign.
  - If not, it is an argument
  - If yes, it is a property, check for an optional tag and a value

The `propertyOrArgument` rule returns whether it encountered trailing node-space, which is then used in the `node` rule.